### PR TITLE
Update build section to use WINE_XIV_FEDORA_LINUX

### DIFF
--- a/XIVLauncher4rpm.spec
+++ b/XIVLauncher4rpm.spec
@@ -117,7 +117,7 @@ fi
 rm -rf %{launcher}
 mkdir -p %{launcher}
 cd %{_builddir}/%{repo0}/src/XIVLauncher.Core
-dotnet publish -r linux-x64 --sc -o "%{launcher}" --configuration Release
+dotnet publish -r linux-x64 --sc -o "%{launcher}" --configuration Release -p:DefineConstants=WINE_XIV_FEDORA_LINUX
 cp ../../misc/linux_distrib/512.png %{launcher}/xivlauncher.png
 cd %{_builddir}/%{repo1}
 cp openssl_fix.cnf xivlauncher.sh XIVLauncher.desktop COPYING %{launcher}/


### PR DESCRIPTION
This will set xlcore to download the wine-xiv release for Fedora instead of Ubuntu (the default).

Users should be encouraged to rebuild as this could potentially cause issues if system libraries don't match.