### PR TITLE
Better tags

### DIFF
--- a/.copr/getsources.sh
+++ b/.copr/getsources.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
-UpstreamTag=6246fde
-DownstreamTag=1.0.1.0-3a
+UpstreamTag=$(awk 'NR==2 {print; exit}' < _version)
+DownstreamTag=$(awk 'NR==3 {print; exit}' < _version)-$(awk 'NR==4 {print; exit}' < _version)
 xlsource=$(rpmbuild --eval='%_sourcedir')
-curl -L https://github.com/goatcorp/FFXIVQuickLauncher/archive/$UpstreamTag.tar.gz -o $xlsource/FFXIVQuickLauncher-$UpstreamTag.tar.gz
-curl -L https://github.com/rankynbass/XIVLauncher4rpm/archive/$DownstreamTag.tar.gz -o $xlsource/XIVLauncher4rpm-$DownstreamTag.tar.gz
+source0=$xlsource/FFXIVQuickLauncher-$UpstreamTag.tar.gz
+source1=$xlsource/XIVLauncher4rpm-$DownstreamTag.tar.gz
+if [ ! -f "$source0" ];
+then
+    curl -L https://github.com/goatcorp/FFXIVQuickLauncher/archive/$UpstreamTag.tar.gz -o $source0
+fi
+if [ ! -f "$source1" ];
+then
+    curl -L https://github.com/rankynbass/XIVLauncher4rpm/archive/$DownstreamTag.tar.gz -o $source1
+fi

--- a/.copr/getsources.sh
+++ b/.copr/getsources.sh
@@ -4,11 +4,22 @@ DownstreamTag=$(awk 'NR==3 {print; exit}' < _version)-$(awk 'NR==4 {print; exit}
 xlsource=$(rpmbuild --eval='%_sourcedir')
 source0=$xlsource/FFXIVQuickLauncher-$UpstreamTag.tar.gz
 source1=$xlsource/XIVLauncher4rpm-$DownstreamTag.tar.gz
+# Make sure the script can run properly no matter where it's called from
+# The below line will always point to the repo's root directory.
+repodir=$(dirname "${BASH_SOURCE[0]}")/../
+cd $repodir
 if [ ! -f "$source0" ];
 then
     curl -L https://github.com/goatcorp/FFXIVQuickLauncher/archive/$UpstreamTag.tar.gz -o $source0
 fi
 if [ ! -f "$source1" ];
 then
-    curl -L https://github.com/rankynbass/XIVLauncher4rpm/archive/$DownstreamTag.tar.gz -o $source1
+    # We could download the correct git tag as a tar.gz file, but we already have all the files here! Why do that?
+    # Make a directory, copy the files of the repo into the directory, then tar the results, excluding the .git folder.
+    mkdir -p XIVLauncher4rpm-$DownstreamTag
+    cp -r `ls -A | grep -v "XIVLauncher4rpm-$DownstreamTag"` XIVLauncher4rpm-$DownstreamTag
+    tar --exclude '.git' -czf $source1 XIVLauncher4rpm-$DownstreamTag
+    # Delete the temp folder we just made.
+    rm -rf XIVLauncher4rpm-$DownstreamTag
 fi
+cp _version $xlsource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+### Sun Sep 04 2022 Rankyn Bass <rankyn@proton.me>
+Bump version-release to 1.0.1.0-4, because 3a is not > 3
+
+Added _version file. This contains UpstreamTag, Version, and Release.
+
+Modify getsources.sh
+
+- Build XIVLauncher4rpm tarball from local git clone.
+- Put in if statements for local builds.
+- Now gets UpstreamTag, DownstreamTag from _version file.
+
+Modify spec file
+
+- Now gets UpstreamTag, xlversion, and xlrelease from _version file.
+- Moved source2 up above definitions, because I need it declared before using it in %define tags.
+
+### Sun Sep 04 2022 Rankyn Bass <rankyn@proton.me>
+Bump version-release to 1.0.1.0-3a
+
+Modify Makefile, getsources.sh
+
+- Remove wget, replace with curl
+
+Modify spec file
+
+- Add -p:BuildHash=UpstreamTag to prevent git describe.
+- Drop unneeded git build dependency
+- Drop git init section
+- Add xivlogo.png to install directory (from misc/header.png)
+
+### Fri Sep 02 2022 Rankyn Bass <rankyn@proton.me>
+Bump version-release to 1.0.1.0-3
+
+Modify Makefile, add getsources script
+
+- No longer requires git. Now just needs wget.
+- Makefile now calls getsources.sh, which uses wget to download sources
+- getsources.sh MUST have matching UpstreamTag and DownstreamTag in spec file.
+- No longer call rpmbuild -bp, which should fix problems with building srpm.
+
+Modify spec file
+
+- Now works with downloaded sources instead of downloading with git during prep stage.
+- Reorganized importand definitions (%define) to the top of the script
+- Worked out a method to deal with ugly long hash name in upstream tarball
+- %setup macro was unpacking source0 tarball multiple times. This has been fixed.
+- More inline documentation of macros and shell commands.
+- Fixed warnings about macros expanding in comments.
+
+Modify README.md
+
+    - Updated build instructions.
+    - Included install instructions for openSUSE.
+
+### Mon Aug 29 2022 Rankyn Bass <rankyn@proton.me>
+First changelog entry for setting up for COPR.

--- a/XIVLauncher4rpm.spec
+++ b/XIVLauncher4rpm.spec
@@ -13,10 +13,9 @@
 # Fedora - 35 and 36
 # OpenSuse - Leap 15.4 and Tumbleweed
 
-# SOURCES
-# I've put them up here because I need them one of them declared before it's used in some definitions.
-Source0:        FFXIVQuickLauncher-%{UpstreamTag}.tar.gz
-Source1:        XIVLauncher4rpm-%{DownstreamTag}.tar.gz
+# Version File Source
+# I've put it here because I need it declared before it's used in some definitions. And it's Source2 because I'm
+# not going to renumber them.
 Source2:        _version
 
 # DEFINITIONS
@@ -34,6 +33,8 @@ Summary:        Custom Launcher for the MMORPG Final Fantasy XIV (Native RPM pac
 Group:          Applications/Games
 License:        GPL-3.0-only
 URL:            https://github.com/rankynbass/XIVLauncher4rpm
+Source0:        FFXIVQuickLauncher-%{UpstreamTag}.tar.gz
+Source1:        XIVLauncher4rpm-%{DownstreamTag}.tar.gz
 
 
 # These package names are from the fedora / redhat repos. Other rpm distros might
@@ -165,7 +166,7 @@ rm -rf %{_builddir}/*
     - Now gets UpstreamTag, DownstreamTag from _version file.
 - Modify spec file
     - Now gets UpstreamTag, xlversion, and xlrelease from _version file.
-    - Moved sources up above definitions, because I need them declared before using them in %%define tags.
+    - Moved source2 up above definitions, because I need it declared before using it in %%define tags.
 
 * Sun Sep 04 2022 Rankyn Bass <rankyn@proton.me>
 - Bump version-release to 1.0.1.0-3a

--- a/XIVLauncher4rpm.spec
+++ b/XIVLauncher4rpm.spec
@@ -14,8 +14,8 @@
 # OpenSuse - Leap 15.4 and Tumbleweed
 
 # DEFINITIONS
-%define xlversion 1.0.1.0
-%define xlrelease 3a
+%define xlversion %(awk 'NR==3 {print; exit}' < _version)
+%define xlrelease %(awk 'NR==4 {print; exit}' < _version)
 
 # REPO TAGS
 # These MUST match the values in .copr/getsources.sh
@@ -23,7 +23,7 @@
 # UpstreamTag is the goatcorp/FFXIVQuickLauncher repo, and DownstreamTag is the rankynbass/XIVLauncher4rpm repo.
 # You can use any tag, branch, or commit. master is primary branch for UpstreamTag, and main for DownstreamTag.
 # Default for DownstreamTag should be %%{xlversion}-%%{xlrelease}
-%define UpstreamTag 6246fde
+%define UpstreamTag %(awk 'NR==2 {print; exit}' < _version)
 %define DownstreamTag %{xlversion}-%{xlrelease}
 
 Name:           XIVLauncher

--- a/XIVLauncher4rpm.spec
+++ b/XIVLauncher4rpm.spec
@@ -157,44 +157,4 @@ rm -rf %{_builddir}/*
 %license /usr/share/doc/xivlauncher/COPYING
 
 %changelog
-* Sun Sep 04 2022 Rankyn Bass <rankyn@proton.me>
-- Bump version-release to 1.0.1.0-4, because 3a is not > 3
-- Added _version file. This contains UpstreamTag, Version, and Release.
-- Modify getsources.sh
-    - Build XIVLauncher4rpm tarball from local git clone.
-    - Put in if statements for local builds.
-    - Now gets UpstreamTag, DownstreamTag from _version file.
-- Modify spec file
-    - Now gets UpstreamTag, xlversion, and xlrelease from _version file.
-    - Moved source2 up above definitions, because I need it declared before using it in %%define tags.
-
-* Sun Sep 04 2022 Rankyn Bass <rankyn@proton.me>
-- Bump version-release to 1.0.1.0-3a
-- Modify Makefile, getsources.sh
-    - Remove wget, replace with curl
-- Modify spec file
-    - Add -p:BuildHash=UpstreamTag to prevent git describe.
-    - Drop unneeded git build dependency
-    - Drop git init section
-    - Add xivlogo.png to install directory (from misc/header.png)
-
-* Fri Sep 02 2022 Rankyn Bass <rankyn@proton.me>
-- Bump version-release to 1.0.1.0-3
-- Modify Makefile, add getsources script
-    - No longer requires git. Now just needs wget.
-    - Makefile now calls getsources.sh, which uses wget to download sources
-    - getsources.sh MUST have matching UpstreamTag and DownstreamTag in spec file.
-    - No longer call rpmbuild -bp, which should fix problems with building srpm.
-- Modify spec file
-    - Now works with downloaded sources instead of downloading with git during prep stage.
-    - Reorganized importand definitions (%%define) to the top of the script
-    - Worked out a method to deal with ugly long hash name in upstream tarball
-    - %%setup macro was unpacking source0 tarball multiple times. This has been fixed.
-    - More inline documentation of macros and shell commands.
-    - Fixed warnings about macros expanding in comments.
-- Modify README.md
-    - Updated build instructions.
-    - Included install instructions for openSUSE.
-
-* Mon Aug 29 2022 Rankyn Bass <rankyn@proton.me>
-- First changelog entry - setting up for COPR.
+# See CHANGELOG.md

--- a/XIVLauncher4rpm.spec
+++ b/XIVLauncher4rpm.spec
@@ -7,23 +7,22 @@
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/RPMMacros/
 # https://docs.fedoraproject.org/en-US/legal/license-field/
 
-## COMPATABILITY
+# COMPATABILITY
 # I've tested on the following distros. It will at least install and launch, although I haven't installed
 # or played on all of them.
 # Fedora - 35 and 36
 # OpenSuse - Leap 15.4 and Tumbleweed
 
-# DEFINITIONS
-%define xlversion %(awk 'NR==3 {print; exit}' < _version)
-%define xlrelease %(awk 'NR==4 {print; exit}' < _version)
+# SOURCES
+Source0:        FFXIVQuickLauncher-%{UpstreamTag}.tar.gz
+Source1:        XIVLauncher4rpm-%{DownstreamTag}.tar.gz
+Source2:        _version
 
-# REPO TAGS
-# These MUST match the values in .copr/getsources.sh
-# Pick a tag, branch, or commit to checkout from the repos.
-# UpstreamTag is the goatcorp/FFXIVQuickLauncher repo, and DownstreamTag is the rankynbass/XIVLauncher4rpm repo.
-# You can use any tag, branch, or commit. master is primary branch for UpstreamTag, and main for DownstreamTag.
-# Default for DownstreamTag should be %%{xlversion}-%%{xlrelease}
-%define UpstreamTag %(awk 'NR==2 {print; exit}' < _version)
+# DEFINITIONS
+# Repo tags are now pulled from the _version file, so it only has to be changed in one place.
+%define UpstreamTag %(awk 'NR==2 {print; exit}' < %{SOURCE2} )
+%define xlversion %(awk 'NR==3 {print; exit}' < %{SOURCE2} )
+%define xlrelease %(awk 'NR==4 {print; exit}' < %{SOURCE2} )
 %define DownstreamTag %{xlversion}-%{xlrelease}
 
 Name:           XIVLauncher
@@ -33,8 +32,7 @@ Summary:        Custom Launcher for the MMORPG Final Fantasy XIV (Native RPM pac
 Group:          Applications/Games
 License:        GPL-3.0-only
 URL:            https://github.com/rankynbass/XIVLauncher4rpm
-Source0:        FFXIVQuickLauncher-%{UpstreamTag}.tar.gz
-Source1:        XIVLauncher4rpm-%{DownstreamTag}.tar.gz
+
 
 # These package names are from the fedora / redhat repos. Other rpm distros might
 # have different names for these.
@@ -156,6 +154,16 @@ rm -rf %{_builddir}/*
 %license /usr/share/doc/xivlauncher/COPYING
 
 %changelog
+* Sun Sep 04 2022 Rankyn Bass <rankyn@proton.me>
+- Bump version-release to 1.0.1.0-4, because 3a is not > 3
+- Added _version file. This contains UpstreamTag, Version, and Release.
+- Modify getsources.sh
+    - Build XIVLauncher4rpm tarball from local git clone.
+    - Put in if statements for local builds.
+    - Now gets UpstreamTag, DownstreamTag from _version file.
+- Modify spec file
+    - Now gets UpstreamTag, xlversion, and xlrelease from _version file.
+
 * Sun Sep 04 2022 Rankyn Bass <rankyn@proton.me>
 - Bump version-release to 1.0.1.0-3a
 - Modify Makefile, getsources.sh

--- a/XIVLauncher4rpm.spec
+++ b/XIVLauncher4rpm.spec
@@ -14,12 +14,14 @@
 # OpenSuse - Leap 15.4 and Tumbleweed
 
 # SOURCES
+# I've put them up here because I need them one of them declared before it's used in some definitions.
 Source0:        FFXIVQuickLauncher-%{UpstreamTag}.tar.gz
 Source1:        XIVLauncher4rpm-%{DownstreamTag}.tar.gz
 Source2:        _version
 
 # DEFINITIONS
 # Repo tags are now pulled from the _version file, so it only has to be changed in one place.
+# This is why sources were declared above.
 %define UpstreamTag %(awk 'NR==2 {print; exit}' < %{SOURCE2} )
 %define xlversion %(awk 'NR==3 {print; exit}' < %{SOURCE2} )
 %define xlrelease %(awk 'NR==4 {print; exit}' < %{SOURCE2} )
@@ -163,6 +165,7 @@ rm -rf %{_builddir}/*
     - Now gets UpstreamTag, DownstreamTag from _version file.
 - Modify spec file
     - Now gets UpstreamTag, xlversion, and xlrelease from _version file.
+    - Moved sources up above definitions, because I need them declared before using them in %%define tags.
 
 * Sun Sep 04 2022 Rankyn Bass <rankyn@proton.me>
 - Bump version-release to 1.0.1.0-3a

--- a/_version
+++ b/_version
@@ -1,4 +1,4 @@
 # Line 2: UpstreamTag, Line 3: Version, Line 4: Release. DO NOT DELETE THIS COMMENT LINE 
 6246fde
 1.0.1.0
-3
+4

--- a/_version
+++ b/_version
@@ -1,0 +1,4 @@
+# Line 2: UpstreamTag, Line 3: Version, Line 4: Release. DO NOT DELETE THIS COMMENT LINE 
+6246fde
+1.0.1.0
+3


### PR DESCRIPTION
Moved the UpstreamTag, Version, and Release tags to the _version file, and then redid the .copr/getsources.sh and XIVLauncher.spec file to pull their values from that file. Also just had getsources.sh package the XIVLauncher4rpm repo instead of downloading it again. And that means I can test without commiting and pushing a test branch up to the repo.