### PR TITLE
R6

### DIFF
--- a/.copr/getsources.sh
+++ b/.copr/getsources.sh
@@ -1,25 +1,26 @@
 #!/bin/bash
 UpstreamTag=$(awk 'NR==2 {print; exit}' < _version)
 DownstreamTag=$(awk 'NR==3 {print; exit}' < _version)-$(awk 'NR==4 {print; exit}' < _version)
+GitRepo=$(awk 'NR==5 {print; exit}' < _version)
 xlsource=$(rpmbuild --eval='%_sourcedir')
 source0=$xlsource/FFXIVQuickLauncher-$UpstreamTag.tar.gz
 source1=$xlsource/XIVLauncher4rpm-$DownstreamTag.tar.gz
 # Make sure the script can run properly no matter where it's called from
 # The below line will always point to the repo's root directory.
-repodir=$(dirname "${BASH_SOURCE[0]}")/../
-cd $repodir
+repodir="$(realpath "$(dirname "${BASH_SOURCE[0]}")/../")"
+cd "$repodir" || exit
 if [ ! -f "$source0" ];
 then
-    curl -L https://github.com/goatcorp/FFXIVQuickLauncher/archive/$UpstreamTag.tar.gz -o $source0
+    curl -L "$GitRepo/archive/$UpstreamTag.tar.gz" -o "$source0"
 fi
 if [ ! -f "$source1" ];
 then
     # We could download the correct git tag as a tar.gz file, but we already have all the files here! Why do that?
     # Make a directory, copy the needed files of the repo into the directory, then tar the results.
-    mkdir -p XIVLauncher4rpm-$DownstreamTag
-    cp cleanupprofile.sh openssl_fix.cnf xivlauncher.sh XIVLauncher.desktop COPYING XIVLauncher4rpm-$DownstreamTag/
-    tar -czf $source1 XIVLauncher4rpm-$DownstreamTag
+    mkdir -p "XIVLauncher4rpm-$DownstreamTag"
+    cp cleanupprofile.sh openssl_fix.cnf xivlauncher.sh XIVLauncher.desktop COPYING "XIVLauncher4rpm-$DownstreamTag/"
+    tar -czf "$source1" "XIVLauncher4rpm-$DownstreamTag"
     # Delete the temp folder we just made.
-    rm -rf XIVLauncher4rpm-$DownstreamTag
+    rm -rf "XIVLauncher4rpm-$DownstreamTag"
 fi
-cp _version $xlsource
+cp _version "$xlsource"

--- a/.copr/local.sh
+++ b/.copr/local.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-
+UpstreamTag=$(awk 'NR==2 {print; exit}' < _version)
+DownstreamTag=$(awk 'NR==3 {print; exit}' < _version)-$(awk 'NR==4 {print; exit}' < _version)
 LocalRepo="$HOME/build/FFXIVQuickLauncher"
-
 xlsource="$(rpmbuild --eval='%_sourcedir')"
 
 # Make sure the script can run properly no matter where it's called from
@@ -10,25 +10,15 @@ repodir="$(realpath "$(dirname "${BASH_SOURCE[0]}")/../")"
 
 # Make tarball from local FFXIVQuickLauncher repo
 cd "$LocalRepo/.." || exit
-xlcommit=local
-xltimestamp="$(date -u +'%y.%m.%d.%H%M')"
-tar -czf "$xlsource/FFXIVQuickLauncher-$xlcommit.tar.gz" --exclude="FFXIVQuickLauncher/.git" "FFXIVQuickLauncher"
+tar -czf "$xlsource/FFXIVQuickLauncher-$UpstreamTag.tar.gz" --exclude="FFXIVQuickLauncher/.git" "FFXIVQuickLauncher"
 
 cd "$repodir" || exit
 # We could download the correct git tag as a tar.gz file, but we already have all the files here! Why do that?
 # Make a directory, copy the needed files of the repo into the directory, then tar the results.
-DownstreamTag="$xltimestamp-utc"
 mkdir -p "XIVLauncher4rpm-$DownstreamTag"
 cp cleanupprofile.sh openssl_fix.cnf xivlauncher.sh XIVLauncher.desktop COPYING "XIVLauncher4rpm-$DownstreamTag/"
 tar -czf "$xlsource/XIVLauncher4rpm-$DownstreamTag.tar.gz" "XIVLauncher4rpm-$DownstreamTag"
 # Delete the temp folder we just made.
 rm -rf "XIVLauncher4rpm-$DownstreamTag"
 
-# Build the _version file. Make sure all lines are correct.
-# This is a "safe" way to do it. This makes sure the version file didn't get any added lines at the end.
-{
-    echo "# Line 2: UpstreamTag, Line 3: Version, Line 4: Release. DO NOT DELETE THIS COMMENT LINE"
-    echo "$xlcommit"
-    echo "$xltimestamp"
-    echo "utc"
-} > "$xlsource/_version"
+cp _version "$xlsource"

--- a/.copr/local.sh
+++ b/.copr/local.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+LocalRepo="$HOME/build/FFXIVQuickLauncher"
+
+xlsource="$(rpmbuild --eval='%_sourcedir')"
+
+# Make sure the script can run properly no matter where it's called from
+# The below lines will always point to the repo's root directory.
+repodir="$(realpath "$(dirname "${BASH_SOURCE[0]}")/../")"
+
+# Make tarball from local FFXIVQuickLauncher repo
+cd "$LocalRepo/.." || exit
+xlcommit=local
+xltimestamp="$(date -u +'%y.%m.%d.%H%M')"
+tar -czf "$xlsource/FFXIVQuickLauncher-$xlcommit.tar.gz" --exclude="FFXIVQuickLauncher/.git" "FFXIVQuickLauncher"
+
+cd "$repodir" || exit
+# We could download the correct git tag as a tar.gz file, but we already have all the files here! Why do that?
+# Make a directory, copy the needed files of the repo into the directory, then tar the results.
+DownstreamTag="$xltimestamp-utc"
+mkdir -p "XIVLauncher4rpm-$DownstreamTag"
+cp cleanupprofile.sh openssl_fix.cnf xivlauncher.sh XIVLauncher.desktop COPYING "XIVLauncher4rpm-$DownstreamTag/"
+tar -czf "$xlsource/XIVLauncher4rpm-$DownstreamTag.tar.gz" "XIVLauncher4rpm-$DownstreamTag"
+# Delete the temp folder we just made.
+rm -rf "XIVLauncher4rpm-$DownstreamTag"
+
+# Build the _version file. Make sure all lines are correct.
+# This is a "safe" way to do it. This makes sure the version file didn't get any added lines at the end.
+{
+    echo "# Line 2: UpstreamTag, Line 3: Version, Line 4: Release. DO NOT DELETE THIS COMMENT LINE"
+    echo "$xlcommit"
+    echo "$xltimestamp"
+    echo "utc"
+} > "$xlsource/_version"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### Sun Sep 25 2022 Rankyn Bass <rankyn@proton.me>
+Bump version-release to 1.0.1.0-5
+
+Update to latest git commit.
+
+Modified xivlauncher.sh to indicate how to add env variables.
+
+Modified spec file so titlebar will show "1.0.1.0 (hashnum) (rpm)"
+
+Modified .desktop file to include (rpm) in the title, so it's different from flatpak install.
+
 ### Sat Sep 10 2022 Rankyn Bass <rankyn@proton.me>
 Bump version-release to 1.0.1.0-5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### Sun Sep 25 2022 Rankyn Bass <rankyn@proton.me>
-Bump version-release to 1.0.1.0-5
+Bump version-release to 1.0.1.0-6
 
 Update to latest git commit.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,16 @@
 # Changelog
-
-### Sat Oct 01 2022 Rankyn Bass <rankyn@proton.me>
-Modified getsources.sh and version file to allow alternate forks of FFXIVQuickLauncher
-
-Pointed to my fork, with tspack commit used for upstream tag.
-
-Changed title bar from rpm to native.
-
-### Sun Sep 25 2022 Rankyn Bass <rankyn@proton.me>
+### Sun Oct 2 2022 Rankyn Bass <rankyn@proton.me>
 Bump version-release to 1.0.1.0-6
 
-Update to latest git commit.
+Modified getsources.sh and version file to allow alternate forks of FFXIVQuickLauncher
+
+Added local.sh to make it easier to test new builds without doing commits or git pushes.
 
 Modified xivlauncher.sh to indicate how to add env variables.
 
-Modified spec file so titlebar will show "1.0.1.0 (hashnum) (rpm)"
+Modified spec file so titlebar will show "1.0.1.0 (native) (hashnum)"
 
-Modified .desktop file to include (rpm) in the title, so it's different from flatpak install.
+Modified .desktop file to include (native) in the title, so it's different from flatpak install.
 
 ### Sat Sep 10 2022 Rankyn Bass <rankyn@proton.me>
 Bump version-release to 1.0.1.0-5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### Sat Oct 01 2022 Rankyn Bass <rankyn@proton.me>
+Modified getsources.sh and version file to allow alternate forks of FFXIVQuickLauncher
+
+Pointed to my fork, with tspack commit used for upstream tag.
+
+Changed title bar from rpm to native.
+
 ### Sun Sep 25 2022 Rankyn Bass <rankyn@proton.me>
 Bump version-release to 1.0.1.0-6
 

--- a/XIVLauncher.desktop
+++ b/XIVLauncher.desktop
@@ -1,6 +1,6 @@
 #!/usr/bin/env xdg-open
 [Desktop Entry]
-Name=XIVLauncher (rpm)
+Name=XIVLauncher (native)
 Comment=Custom launcher for Final Fantasy XIV. Native version from copr or rpm.
 Exec=/usr/bin/xivlauncher
 Icon=xivlauncher

--- a/XIVLauncher.desktop
+++ b/XIVLauncher.desktop
@@ -1,6 +1,6 @@
 #!/usr/bin/env xdg-open
 [Desktop Entry]
-Name=XIVLauncher
+Name=XIVLauncher (native)
 Comment=Custom launcher for Final Fantasy XIV. Native version from copr or rpm.
 Exec=/usr/bin/xivlauncher
 Icon=xivlauncher

--- a/XIVLauncher.desktop
+++ b/XIVLauncher.desktop
@@ -1,6 +1,6 @@
 #!/usr/bin/env xdg-open
 [Desktop Entry]
-Name=XIVLauncher (native)
+Name=XIVLauncher (rpm)
 Comment=Custom launcher for Final Fantasy XIV. Native version from copr or rpm.
 Exec=/usr/bin/xivlauncher
 Icon=xivlauncher

--- a/XIVLauncher4rpm.spec
+++ b/XIVLauncher4rpm.spec
@@ -105,7 +105,7 @@ cd %{_builddir}
 # build requirement (and dirty hack of doing git init) and drastically speeds up the compile.
 cd %{_builddir}/%{repo0}
 cd %{_builddir}/%{repo0}/src/XIVLauncher.Core
-dotnet publish -r linux-x64 --sc -o "%{_builddir}/%{repo1}" --configuration Release -p:DefineConstants=WINE_XIV_FEDORA_LINUX -p:BuildHash="%{UpstreamTag}) (rpm"
+dotnet publish -r linux-x64 --sc -o "%{_builddir}/%{repo1}" --configuration Release -p:DefineConstants=WINE_XIV_FEDORA_LINUX -p:BuildHash="RPM) (%{UpstreamTag}"
 cp ../../misc/linux_distrib/512.png %{_builddir}/%{repo1}/xivlauncher.png
 cp ../../misc/header.png %{_builddir}/%{repo1}/xivlogo.png
 cd %{_builddir}/%{repo1}

--- a/XIVLauncher4rpm.spec
+++ b/XIVLauncher4rpm.spec
@@ -105,7 +105,7 @@ cd %{_builddir}
 # build requirement (and dirty hack of doing git init) and drastically speeds up the compile.
 cd %{_builddir}/%{repo0}
 cd %{_builddir}/%{repo0}/src/XIVLauncher.Core
-dotnet publish -r linux-x64 --sc -o "%{_builddir}/%{repo1}" --configuration Release -p:DefineConstants=WINE_XIV_FEDORA_LINUX -p:BuildHash="RPM) (%{UpstreamTag}"
+dotnet publish -r linux-x64 --sc -o "%{_builddir}/%{repo1}" --configuration Release -p:DefineConstants=WINE_XIV_FEDORA_LINUX -p:BuildHash="native) (%{UpstreamTag}"
 cp ../../misc/linux_distrib/512.png %{_builddir}/%{repo1}/xivlauncher.png
 cp ../../misc/header.png %{_builddir}/%{repo1}/xivlogo.png
 cd %{_builddir}/%{repo1}

--- a/XIVLauncher4rpm.spec
+++ b/XIVLauncher4rpm.spec
@@ -105,7 +105,7 @@ cd %{_builddir}
 # build requirement (and dirty hack of doing git init) and drastically speeds up the compile.
 cd %{_builddir}/%{repo0}
 cd %{_builddir}/%{repo0}/src/XIVLauncher.Core
-dotnet publish -r linux-x64 --sc -o "%{_builddir}/%{repo1}" --configuration Release -p:DefineConstants=WINE_XIV_FEDORA_LINUX -p:BuildHash=%{UpstreamTag}
+dotnet publish -r linux-x64 --sc -o "%{_builddir}/%{repo1}" --configuration Release -p:DefineConstants=WINE_XIV_FEDORA_LINUX -p:BuildHash="%{UpstreamTag}) (rpm"
 cp ../../misc/linux_distrib/512.png %{_builddir}/%{repo1}/xivlauncher.png
 cp ../../misc/header.png %{_builddir}/%{repo1}/xivlogo.png
 cd %{_builddir}/%{repo1}

--- a/XIVLauncher4rpm.spec
+++ b/XIVLauncher4rpm.spec
@@ -60,6 +60,7 @@ Requires:       (libpcap or libpcap1)
 Requires:       (libFAudio or libFAudio0)
 Requires:       desktop-file-utils
 Requires:       jxrlib
+Provides:       xivlauncher
 
 # There isn't any linux / rpm debug info available with the source git
 %global debug_package %{nil}
@@ -115,12 +116,13 @@ cd %{_builddir}/%{repo1}
 install -d "%{buildroot}/usr/bin"
 install -d "%{buildroot}/opt/XIVLauncher"
 install -d "%{buildroot}/usr/share/doc/xivlauncher"
-install -D -m 644 "%{_builddir}/%{repo1}/XIVLauncher.desktop" "%{buildroot}/usr/share/applications/XIVLauncher.desktop"
+install -d "%{buildroot}/usr/share/applications"
 install -D -m 644 "%{_builddir}/%{repo1}/xivlauncher.png" "%{buildroot}/usr/share/pixmaps/xivlauncher.png"
 cp -r "%{_builddir}/%{repo1}"/* "%{buildroot}/opt/XIVLauncher"
 cp %{buildroot}/opt/XIVLauncher/COPYING %{buildroot}/usr/share/doc/xivlauncher/COPYING
 cd %{buildroot}
 ln -sr "opt/XIVLauncher/xivlauncher.sh" "usr/bin/xivlauncher"
+ln -sr "opt/XIVLauncher/XIVLauncher.desktop" "usr/share/applications/XIVLauncher-native.desktop"
 
 %pre
 
@@ -142,7 +144,7 @@ rm -rf %{_builddir}/*
 ### FILES SECTION
 %files
 /usr/bin/xivlauncher
-/usr/share/applications/XIVLauncher.desktop
+/usr/share/applications/XIVLauncher-native.desktop
 /usr/share/pixmaps/xivlauncher.png
 /opt/XIVLauncher/cleanupprofile.sh
 /opt/XIVLauncher/COPYING

--- a/_version
+++ b/_version
@@ -1,5 +1,5 @@
 # Line 1: This comment. Line 2: UpstreamTag. Line 3: Version. Line 4: Release. Line 5: Github repo
-fc7f1b8
+6246fde
 1.0.1.0
-7
-https://github.com/rankynbass/FFXIVQuickLauncher
+6
+https://github.com/goatcorp/FFXIVQuickLauncher

--- a/_version
+++ b/_version
@@ -1,4 +1,5 @@
-# Line 2: UpstreamTag, Line 3: Version, Line 4: Release. DO NOT DELETE THIS COMMENT LINE 
-9a93fe4
+# Line 1: This comment. Line 2: UpstreamTag. Line 3: Version. Line 4: Release. Line 5: Github repo
+fc7f1b8
 1.0.1.0
 6
+https://github.com/rankynbass/FFXIVQuickLauncher

--- a/_version
+++ b/_version
@@ -1,5 +1,5 @@
 # Line 1: This comment. Line 2: UpstreamTag. Line 3: Version. Line 4: Release. Line 5: Github repo
 fc7f1b8
 1.0.1.0
-6
+7
 https://github.com/rankynbass/FFXIVQuickLauncher

--- a/_version
+++ b/_version
@@ -1,4 +1,4 @@
 # Line 2: UpstreamTag, Line 3: Version, Line 4: Release. DO NOT DELETE THIS COMMENT LINE 
-6246fde
+9a93fe4
 1.0.1.0
-5
+6

--- a/xivlauncher.sh
+++ b/xivlauncher.sh
@@ -6,7 +6,4 @@ export OPENSSL_CONF=/opt/XIVLauncher/openssl_fix.cnf
 # export MANGOHUD=1
 # export MANGOHUD_CONFIGFILE=~/.config/MangoHud/MangoHud.conf
 
-# Steam overlay (doesn't work yet)
-# export LD_PRELOAD="$HOME/.local/share/Steam/ubuntu12_64/gameoverlayrenderer.so"
-
 /opt/XIVLauncher/XIVLauncher.Core &

--- a/xivlauncher.sh
+++ b/xivlauncher.sh
@@ -1,2 +1,12 @@
 #!/usr/bin/bash
-OPENSSL_CONF=/opt/XIVLauncher/openssl_fix.cnf /opt/XIVLauncher/XIVLauncher.Core &
+
+# Define env variables. Top one is mandatory. 
+export OPENSSL_CONF=/opt/XIVLauncher/openssl_fix.cnf
+# export DXVK_FRAME_RATE=60
+# export MANGOHUD=1
+# export MANGOHUD_CONFIGFILE=~/.config/MangoHud/MangoHud.conf
+
+# Steam overlay (doesn't work yet)
+# export LD_PRELOAD="$HOME/.local/share/Steam/ubuntu12_64/gameoverlayrenderer.so"
+
+/opt/XIVLauncher/XIVLauncher.Core &


### PR DESCRIPTION
Tweaks to scripts and spec file to make future releases easier. Title bar should now be "XIVLauncher 1.0.1.0 (native) (6246fde)". The .desktop file will now provide the title "XIVLauncher (native)" so that it's easy to distinguish from the flatpak install. The xivlauncher script at /usr/bin is a soft link from /opt/XIVLauncher/xivlauncher.sh, and has been redone to be a little more obvious on how you can modify it. I provided a few optional commented out lines that limit framerate and set up mangohud, but you can always add your own following the same pattern.

There are no functional changes to this release, it's just a code cleanup and renaming a few things.