### PR TITLE
New Version! Updating to use new repos

### DIFF
--- a/.copr/getsources.sh
+++ b/.copr/getsources.sh
@@ -1,25 +1,33 @@
 #!/bin/bash
-UpstreamTag=$(awk 'NR==2 {print; exit}' < _version)
-DownstreamTag=$(awk 'NR==3 {print; exit}' < _version)-$(awk 'NR==4 {print; exit}' < _version)
-GitRepo=$(awk 'NR==5 {print; exit}' < _version)
+CoreRepo=$(awk 'NR==2 {print; exit}' < _version)
+CoreTag=$(awk 'NR==3 {print; exit}' < _version)
+LauncherRepo=$(awk 'NR==4 {print; exit}' < _version)
+LauncherTag=$(awk 'NR==5 {print; exit}' < _version)
+DownstreamTag=$(awk 'NR==6 {print; exit}' < _version)-$(awk 'NR==7 {print; exit}' < _version)
 xlsource=$(rpmbuild --eval='%_sourcedir')
-source0=$xlsource/FFXIVQuickLauncher-$UpstreamTag.tar.gz
-source1=$xlsource/XIVLauncher4rpm-$DownstreamTag.tar.gz
+source0=$xlsource/XIVLauncher.Core-$CoreTag.tar.gz
+source1=$xlsource/FFXIVQuickLauncher-$LauncherTag.tar.gz
+source2=$xlsource/XIVLauncher4rpm-$DownstreamTag.tar.gz
+
 # Make sure the script can run properly no matter where it's called from
 # The below line will always point to the repo's root directory.
 repodir="$(realpath "$(dirname "${BASH_SOURCE[0]}")/../")"
 cd "$repodir" || exit
 if [ ! -f "$source0" ];
 then
-    curl -L "$GitRepo/archive/$UpstreamTag.tar.gz" -o "$source0"
+    curl -L "$CoreRepo/archive/$CoreTag.tar.gz" -o "$source0"
 fi
 if [ ! -f "$source1" ];
+then
+    curl -L "$LauncherRepo/archive/$LauncherTag.tar.gz" -o "$source1"
+fi
+if [ ! -f "$source2" ];
 then
     # We could download the correct git tag as a tar.gz file, but we already have all the files here! Why do that?
     # Make a directory, copy the needed files of the repo into the directory, then tar the results.
     mkdir -p "XIVLauncher4rpm-$DownstreamTag"
     cp cleanupprofile.sh openssl_fix.cnf xivlauncher.sh XIVLauncher.desktop COPYING "XIVLauncher4rpm-$DownstreamTag/"
-    tar -czf "$source1" "XIVLauncher4rpm-$DownstreamTag"
+    tar -czf "$source2" "XIVLauncher4rpm-$DownstreamTag"
     # Delete the temp folder we just made.
     rm -rf "XIVLauncher4rpm-$DownstreamTag"
 fi

--- a/.copr/local.sh
+++ b/.copr/local.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
-UpstreamTag=$(awk 'NR==2 {print; exit}' < _version)
-DownstreamTag=$(awk 'NR==3 {print; exit}' < _version)-$(awk 'NR==4 {print; exit}' < _version)
-LocalRepo="$HOME/build/FFXIVQuickLauncher"
+CoreTag=$(awk 'NR==3 {print; exit}' < _version)
+LauncherTag=$(awk 'NR==5 {print; exit}' < _version)
+DownstreamTag=$(awk 'NR==6 {print; exit}' < _version)-$(awk 'NR==7 {print; exit}' < _version)
+xlsource=$(rpmbuild --eval='%_sourcedir')
+CoreRepo="$HOME/build/XIVLauncher.Core"
+LauncherRepo="$HOME/build/FFXIVQuickLauncher"
 xlsource="$(rpmbuild --eval='%_sourcedir')"
 
 # Make sure the script can run properly no matter where it's called from
@@ -9,8 +12,10 @@ xlsource="$(rpmbuild --eval='%_sourcedir')"
 repodir="$(realpath "$(dirname "${BASH_SOURCE[0]}")/../")"
 
 # Make tarball from local FFXIVQuickLauncher repo
-cd "$LocalRepo/.." || exit
-tar -czf "$xlsource/FFXIVQuickLauncher-$UpstreamTag.tar.gz" --exclude="FFXIVQuickLauncher/.git" "FFXIVQuickLauncher"
+cd "$CoreRepo/.." || exit
+tar -czf "$xlsource/XIVLauncher.Core-$CoreTag.tar.gz" --exclude="FFXIVQuickLauncher/.git" "XIVLauncher.Core"
+cd "$LauncherRepo/.." || exit
+tar -czf "$xlsource/FFXIVQuickLauncher-$LauncherTag.tar.gz" --exclude="FFXIVQuickLauncher/.git" "FFXIVQuickLauncher"
 
 cd "$repodir" || exit
 # We could download the correct git tag as a tar.gz file, but we already have all the files here! Why do that?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Changelog
+### Sun Oct 23 2022 Rankyn Bass <rankyn@proton.me>
+New version! 1.0.2.0-1
+
+Now uses a new repo. _version file, scripts, and spec file adjusted to work with it.
+- pull tarballs from XIVLauncher.Core repo and FFXIVQuickLauncher repo
+- using build hash from XIVLauncher.Core repo for BuildHash
+
+You can now generate a tspack for debugging. It's in the Settings > About tab.
+
+You can now press enter while in the user or password fields and log in.
+
+Update without starting should now actually not start the game.
+
 ### Sun Oct 2 2022 Rankyn Bass <rankyn@proton.me>
 Bump version-release to 1.0.1.0-6
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ XIVLauncher (abbreviated as XL) is a faster launcher for our favorite critically
 
 ### Repos
 [ FFXIVQuickLauncher git: **[goatcorp/FFXIVQuickLauncher](https://github.com/goatcorp/FFXIVQuickLauncher/)** ]
+[ XIVLauncher.Core git: **[goatcorp/XIVLauncher.Core] (https://github.com/goatcorp/XIVLauncher.Core/)** ]
 [ XIVLauncher4rpm git: **[rankynbass/XIVLauncher4rpm](https://github.com/rankynbass/XIVLauncher4rpm)** ]
 [ COPR Repo: **[rankyn/xivlauncher](https://copr.fedorainfracloud.org/coprs/rankyn/xivlauncher/)** ]
 
@@ -121,7 +122,7 @@ git clone https://github.com/rankynbass/XIVLauncher4rpm.git
 cd XIVLauncher4rpm
 ```
 
-Now you can build the rpms. First, download the tarballs by using the included script, then build with rpmbuild. The third option is actually what the COPR build system does. It uses .copr/Makefile to install dependencies for making the binary, then calls the getsources script, then executes rpmbuild -bs. It then passes the src.rpm off to the various build environments for different distros. However, even if you have src.rpms, you still need to have internet access. The dotnet publish command needs to grab some remote packages. For manual builds, thats obviously not an issue, since you just cloned the repo. But for remote builds with copr, or with opensuse's OBS (I haven't tried this one yet), you'll need to make sure the builder has internet access. (version and release are listed in the _version file in lines 3 and 4. As of Sep 5, 2022, these are 1.0.1.0 and 4.)
+Now you can build the rpms. First, download the tarballs by using the included script, then build with rpmbuild. The third option is actually what the COPR build system does. It uses .copr/Makefile to install dependencies for making the binary, then calls the getsources script, then executes rpmbuild -bs. It then passes the src.rpm off to the various build environments for different distros. However, even if you have src.rpms, you still need to have internet access. The dotnet publish command needs to grab some remote packages. For manual builds, thats obviously not an issue, since you just cloned the repo. But for remote builds with copr, or with opensuse's OBS (I haven't tried this one yet), you'll need to make sure the builder has internet access. (version and release are listed in the _version file in lines 3 and 4. As of October 23, 2022, these are 1.0.2.0 and 1.)
 
 Run the script `.copr/getsources.sh` and then do one of the following:
 ```

--- a/_version
+++ b/_version
@@ -1,5 +1,7 @@
 XIVLauncher
-6246fde
-1.0.1.0
-6
+https://github.com/goatcorp/XIVLauncher.Core
+599241d
 https://github.com/goatcorp/FFXIVQuickLauncher
+223db56
+1.0.2.0
+1


### PR DESCRIPTION
New version! 1.0.2.0-1

Now uses a new repo. _version file, scripts, and spec file adjusted to work with it.
- pull tarballs from XIVLauncher.Core repo and FFXIVQuickLauncher repo
- using build hash from XIVLauncher.Core repo for BuildHash

You can now generate a tspack for debugging. It's in the Settings > About tab.

You can now press enter while in the user or password fields and log in.

Update without starting should now actually not start the game.