### PR TITLE
1.0.2-5

### DIFF
--- a/.copr/getsources.sh
+++ b/.copr/getsources.sh
@@ -43,7 +43,7 @@ then
     # We could download the correct git tag as a tar.gz file, but we already have all the files here! Why do that?
     # Make a directory, copy the needed files of the repo into the directory, then tar the results.
     mkdir -p "$workingdir/XIVLauncher4rpm-$DownstreamTag"
-    cp cleanupprofile.sh openssl_fix.cnf xivlauncher.sh XIVLauncher.desktop COPYING "$workingdir/XIVLauncher4rpm-$DownstreamTag/"
+    cp cleanupprofile.sh openssl_fix.cnf xivlauncher.sh XIVLauncher.desktop XIVLauncher-custom.desktop COPYING "$workingdir/XIVLauncher4rpm-$DownstreamTag/"
     cd "$workingdir" || exit
     echo "Making tarball for XIVLauncher4rpm"
     tar --totals -I 'xz -v -9' -cf "$source1" "XIVLauncher4rpm-$DownstreamTag"

--- a/.copr/local.sh
+++ b/.copr/local.sh
@@ -24,7 +24,7 @@ cd "$repodir" || exit
 # We could download the correct git tag as a tar.gz file, but we already have all the files here! Why do that?
 # Make a directory, copy the needed files of the repo into the directory, then tar the results.
 mkdir -p "$workingdir/XIVLauncher4rpm-$DownstreamTag"
-cp cleanupprofile.sh openssl_fix.cnf xivlauncher.sh XIVLauncher.desktop COPYING "$workingdir/XIVLauncher4rpm-$DownstreamTag/"
+cp cleanupprofile.sh openssl_fix.cnf xivlauncher.sh XIVLauncher.desktop XIVLauncher-custom.desktop COPYING "$workingdir/XIVLauncher4rpm-$DownstreamTag/"
 cd "$workingdir" || exit
 echo "Writing XIVLauncher4rpm-$DownstreamTag.tar.xz"
 tar --totals -I 'xz -v -9' -cf "$xlsource/XIVLauncher4rpm-$DownstreamTag.tar.xz" "XIVLauncher4rpm-$DownstreamTag"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,24 @@
 # Changelog
+### Wed Nov 02 2022 Rankyn Bass <rankyn@proton.me>
+Release bumped to 5
+
+Redid the xivlauncher script
+- calling `/usr/bin/xivlauncher` with no arguements just launches XIVLauncher.
+- calling `/usr/bin/xivlauncher custom` will check for `$HOME/.local/bin/xivlauncher-custom.sh`, and launch it if it's found and has valid bash syntax.
+    - If the script is found, but is broken, it'll back it up and create a new one.
+    - If it doesn't find the custom script, it will created it.
+    - If the path `$HOME/.local/bin` doesn't exist, it will be created first. This fixes an error that was reported. This path is *not* part of the XDG basedir specs, but it *is* part of the systemd file heirarchy, and Fedora, openSUSE, Enterprise Linux, and most distros with systemd use it. 
+
 ### Sun Oct 30 2022 Rankyn Bass <rankyn@proton.me>
+Release bumped to 4
+
 Fixed an error in the xivlauncher.sh script
 - The xivlauncher-custom.sh script being created was malformed, resulting in a crash.
 - The xivlauncher script now checks it for syntax errors, and backs it up and creates a new one if there are problems. This should fix it for people who got a poorly formed script file.
 
 ### Sat Oct 29 2022 Rankyn Bass <rankyn@proton.me>
+Release bumped to 3
+
 Minor update to launcher scripts
 - The `/usr/bin/xivlauncher` script now checks `~/.local/bin/xivlauncher-custom.sh` for an openssl config line
 - If it doesn't find one, it adds it to the top of the file (just under `#!/bin/bash`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 Release bumped to 5
 
 Redid the xivlauncher script
-- calling `/usr/bin/xivlauncher` with no arguements just launches XIVLauncher.
-- calling `/usr/bin/xivlauncher custom` will check for `$HOME/.local/bin/xivlauncher-custom.sh`, and launch it if it's found and has valid bash syntax.
+- Running `/usr/bin/xivlauncher` with no arguements just launches XIVLauncher.
+- Running `/usr/bin/xivlauncher custom` will check for `$HOME/.local/bin/xivlauncher-custom.sh`, and launch it if it's found and has valid bash syntax.
     - If the script is found, but is broken, it'll back it up and create a new one.
     - If it doesn't find the custom script, it will created it.
     - If the path `$HOME/.local/bin` doesn't exist, it will be created first. This fixes an error that was reported. This path is *not* part of the XDG basedir specs, but it *is* part of the systemd file heirarchy, and Fedora, openSUSE, Enterprise Linux, and most distros with systemd use it. 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ sudo dnf remove XIVLauncher
 sudo dnf copr remove rankyn/xivlauncher
 ```
 ### openSUSE
-The repo is built for tumbleweed, but works with LEAP 15.3 and 15.4 as well. It's possible anything from the 15.x family will work, but 15.2 hit end-of-life on 2021-12-31, so I won't bother testing it. If you ever have problems with the repo not refreshing properly (not seeing a new update, for example), just uninstall and reinstall the repo.
+The repo is built for tumbleweed, but works with LEAP 15.4 as well. It's possible anything from the 15.x family will work, but 15.2 hit end-of-life on 2021-12-31 and 15.3 will hit EOL on 2022-11-30, so I won't bother testing them. If you ever have problems with the repo not refreshing properly (not seeing a new update, for example), just uninstall and reinstall the repo.
 
 *Install*
 ```
@@ -33,7 +33,6 @@ sudo zypper install XIVLauncher
 ```
 sudo zypper remove XIVLauncher
 sudo zypper removerepo copr:copr.fedorainfracloud.org:rankyn:xivlauncher
-
 ```
 ### Enterprise Linux (EL9 Only)
 Red Hat, Rocky Linux, AlmaLinux, etc.
@@ -62,13 +61,13 @@ sudo dnf copr remove rankyn/xl-deps-el9
 
 ### First run
 
-After install, you should run the `/usr/bin/xivlauncher` script, either from the terminal or from the .desktop file (which should show up in your desktop menu as "XIVLauncher (native)"). This will create another script at `~/.local/bin/xivlauncher-custom.sh` if it doesn't already exist. You can edit `xivlauncher-custom.sh` to add environment variables and call other programs. For example, you could use it to call gamescope or launch an IPC bridge for discord, as well as simpler things like turning on MANGOHUD or a frame rate limit. This script file will not be changed when you upgrade, so your changes will be saved.
+After install, you should can the `/usr/bin/xivlauncher` script, either from the terminal or from the .desktop file (which should show up in your desktop menu as "XIVLauncher Native"). This will launch XIVLauncher.Core. Alternativly, you can run `/usr/bin/xivlauncher custom` (or desktop menu item "XIVLauncher Custom"), which will create run a user-modifiable script at `~/.local/bin/xivlauncher-custom.sh`, creating it first if it doesn't already exist. You can edit `xivlauncher-custom.sh` to add environment variables and call other programs. For example, you could use it to call gamescope or launch an IPC bridge for discord, as well as simpler things like turning on MANGOHUD or adding a frame rate limit. This script file will not be changed when you upgrade, so your changes will be saved.
 
-A script is included at `/opt/XIVLauncher/cleanupprofile.sh` which can clean up your .xlcore folder and improve performance/compatibility with the native XIVLauncher install. If you are upgrading from 1.0.1.0-2 or earlier, or moving from the flatpak install, you should run this. Running this script will delete a few of the folders in ~/.xlcore. When you run XIVLauncher those folders will be recreated with fresh versions. *This may break the flatpak install!* If you are trying to switch back and forth between native and flatpak, you'll have to run this script each time you switch. If you are running a custom version of wine, this script is not necessary.
+Another script is included at `/opt/XIVLauncher/cleanupprofile.sh` which can clean up your `~.xlcore` folder and improve performance/compatibility with the native XIVLauncher install. If you are upgrading from 1.0.1.0-2 or earlier, or moving from the flatpak install, you should run this. Running this script will delete a few of the folders in ~/.xlcore. When you run XIVLauncher those folders will be recreated with fresh versions. *This may break the flatpak install!* If you are trying to switch back and forth between native and flatpak, you may have to run this script each time you switch. If you are running a custom version of wine, this script is not necessary.
 
 ### Non-Steam Configuration
 
-The program installs to `/opt/XIVLauncher`. A .desktop file is included at `/usr/share/applications/XIVLauncher.desktop`, but it might need to be tweaked for your installation. You can also launch it from the terminal with `/usr/bin/xivlauncher`. If you have a non-steam account and you'd like to still launch with steam, follow the instructions below, but leave off the stuff after `%command%` in the launch options, and make sure Use Steam Service is *unchecked* in the launcher.
+The program installs to `/opt/XIVLauncher`. Two .desktop files are included at `/usr/share/applications/XIVLauncher-native.desktop` and `XIVLauncher-custom.desktop`. You can also launch it from the terminal with `/usr/bin/xivlauncher`. If you have a non-steam account and you'd like to still launch with steam, follow the instructions below, but leave off the stuff after `%command%` in the launch options, and make sure Use Steam Service is *unchecked* in the launcher.
 
 ### Steam Configuration
 

--- a/XIVLauncher-custom.desktop
+++ b/XIVLauncher-custom.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=XIVLauncher Custom
+Comment=XIVLauncher custom script (~/.local/bin/xivlauncher-custom.sh)
+Exec=/usr/bin/xivlauncher custom
+Icon=xivlauncher
+Terminal=true
+Type=Application
+Categories=Game;
+StartupWMClass=XIVLauncher.Core

--- a/XIVLauncher.desktop
+++ b/XIVLauncher.desktop
@@ -1,6 +1,5 @@
-#!/usr/bin/env xdg-open
 [Desktop Entry]
-Name=XIVLauncher (native)
+Name=XIVLauncher Native
 Comment=Custom launcher for Final Fantasy XIV. Native version from copr or rpm.
 Exec=/usr/bin/xivlauncher
 Icon=xivlauncher

--- a/XIVLauncher4rpm.spec
+++ b/XIVLauncher4rpm.spec
@@ -119,6 +119,7 @@ cp %{buildroot}/opt/XIVLauncher/COPYING %{buildroot}/usr/share/doc/xivlauncher/C
 cd %{buildroot}
 ln -sr "opt/XIVLauncher/xivlauncher.sh" "usr/bin/xivlauncher"
 ln -sr "opt/XIVLauncher/XIVLauncher.desktop" "usr/share/applications/XIVLauncher-native.desktop"
+ln -sr "opt/XIVLauncher/XIVLauncher-custom.desktop" "usr/share/applications/XIVLauncher-custom.desktop"
 
 %pre
 
@@ -136,6 +137,7 @@ echo "If you are planning to use the flatpak version of XIVLauncher, you should 
 %files
 /usr/bin/xivlauncher
 /usr/share/applications/XIVLauncher-native.desktop
+/usr/share/applications/XIVLauncher-custom.desktop
 /usr/share/pixmaps/xivlauncher.png
 /opt/XIVLauncher/cleanupprofile.sh
 /opt/XIVLauncher/COPYING
@@ -155,6 +157,7 @@ echo "If you are planning to use the flatpak version of XIVLauncher, you should 
 /opt/XIVLauncher/XIVLauncher.Core.pdb
 /opt/XIVLauncher/XIVLauncher.Core.xml
 /opt/XIVLauncher/XIVLauncher.desktop
+/opt/XIVLauncher/XIVLauncher-custom.desktop
 /opt/XIVLauncher/xivlogo.png
 %license /usr/share/doc/xivlauncher/COPYING
 

--- a/_version
+++ b/_version
@@ -4,4 +4,4 @@ ad6b701
 https://github.com/goatcorp/FFXIVQuickLauncher
 223db56
 1.0.2
-4
+5

--- a/badge.json
+++ b/badge.json
@@ -1,6 +1,6 @@
 {
 	"schemaVersion": 1,
 	"label": "copr",
-	"message": "1.0.2-4",
+	"message": "1.0.2-5",
 	"color": "success"
 }

--- a/xivlauncher.sh
+++ b/xivlauncher.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
-xlpath=$HOME/.local/bin/xivlauncher-custom.sh
+# ~/.local/bin is part of the systemd file hierarchy. Fedora and openSUSE both use it.
+bindir=$HOME/.local/bin
+script=xivlauncher-custom.sh
 
-makeCustomScript () {
-    echo "Creating new file $xlpath."
+# Function to make a new custom script
+makeCustomScript ()
+{
+    # These directories don't always exist! Try to create them, just in case.
+    mkdir -p "$bindir"
+    echo "Creating new file $bindir/$script."
     {
         echo '#!/bin/bash'
         echo 'export OPENSSL_CONF=/opt/XIVLauncher/openssl_fix.cnf'
@@ -17,53 +23,93 @@ makeCustomScript () {
         echo '# gamescope -w 1280 -h 720 -W 1920 -H 1440 -U -f -- /opt/XIVLauncher/XIVLauncher.Core'
         echo ''
         echo '/opt/XIVLauncher/XIVLauncher.Core'
-    } > "$xlpath"
-    chmod +x "$xlpath"
+    } > "$bindir/$script"
+    chmod +x "$bindir/$script"
 }
 
-echo "=========================/usr/bin/xivlauncher========================="
-echo "Checking $xlpath"
-# Code to check for bad or missing $HOME/.local/bin/xivlauncher-custom.sh
-if [ -f "$xlpath" ];
-then
-    # Make it executable if it isn't
-    if [ ! -x "$xlpath" ];
+# Function to run without script
+runDefault()
+{
+    echo "======================== /usr/bin/xivlauncher ========================"
+    echo "No custom script in use. If you with to define custom launch options,"
+    echo "run 'xivlauncher custom' at the command line. That will run the custom"
+    echo "script at '~/.local/bin/xivlauncher-custom.sh'. If the script does not"
+    echo "exist, it will be created first."
+    echo "======================== /usr/bin/xivlauncher ========================"
+    export OPENSSL_CONF=/opt/XIVLauncher/openssl_fix.cnf
+    /opt/XIVLauncher/XIVLauncher.Core
+    exit   
+}
+
+# Function to check for custom script
+checkCustom()
+{
+    echo "Checking $bindir/$script"
+    # Code to check for bad or missing $HOME/.local/bin/xivlauncher-custom.sh
+    if [ -f "$bindir/$script" ];
     then
-        chmod +x "$xlpath"
-    fi
-    # Check the file for bash syntax errors.
-    errval=$(bash -n $xlpath 2>&1)
-    retcode=$?
-    if [ ! $retcode == 0 ];
-    then
-        # If errors are found, backup the file and create a fresh one.
-        rm -f "$xlpath.bak"
-        mv "$xlpath" "$xlpath.bak"
-        echo "Couldn't run $xlpath. It has the following error:"
-        echo "$errval"
-        echo "It has been renamed to $xlpath.bak."
-        makeCustomScript
-    else
-        # Otherwise, check for the SSL fix.
-        echo "File exists. Checking for SSL fix."
-        sslfix=$(grep -c 'OPENSSL_CONF=/opt/XIVLauncher/openssl_fix.cnf' "$xlpath")
-        if [ "$sslfix" -eq 0 ];
+        # Make it executable if it isn't
+        if [ ! -x "$bindir/$script" ];
         then
-            # If the OPENSSL_CONF line is not found, insert it.
-            echo "Updating xivlauncher-custom.sh with SSL fix."
-            sed -i '2i\export OPENSSL_CONF=/opt/XIVLauncher/openssl_fix.cnf\' "$xlpath"
+            chmod +x "$bindir/$script"
+        fi
+        # Check the file for bash syntax errors.
+        errval=$(bash -n $bindir/$script 2>&1)
+        retcode=$?
+        if [ ! $retcode == 0 ];
+        then
+            # If errors are found, backup the file and create a fresh one.
+            rm -f "$bindir/$script.bak"
+            mv "$bindir/$script" "$bindir/$script.bak"
+            echo "Couldn't run $bindir/$script. It has the following error:"
+            echo "$errval"
+            echo "It has been renamed to $bindir/$script.bak."
+            makeCustomScript
         else
-            echo "SSL config found."
-        fi   
+            # Otherwise, check for the SSL fix.
+            echo "File exists. Checking for SSL fix."
+            sslfix=$(grep -c 'OPENSSL_CONF=/opt/XIVLauncher/openssl_fix.cnf' "$bindir/$script")
+            if [ "$sslfix" -eq 0 ];
+            then
+                # If the OPENSSL_CONF line is not found, insert it.
+                echo "Updating xivlauncher-custom.sh with SSL fix."
+                sed -i '2i\export OPENSSL_CONF=/opt/XIVLauncher/openssl_fix.cnf\' "$bindir/$script"
+            else
+                echo "SSL config found."
+            fi   
+        fi
+    else
+        # xivlauncher-custom.sh wasn't found, so create it.
+        makeCustomScript
     fi
+}
+
+# Function to run with script
+runCustom()
+{
+    echo "===================== /usr/bin/xivlauncher custom ====================="
+    echo "Running script ~/.local/bin/xivlauncher-custom.sh"
+    echo "If it crashes, please delete it, and run /usr/bin/xivlauncher custom"
+    echo "again. If the problem persists, please file a ticket on"
+    echo "https://github.com/rankynbass/XIVLauncher4rpm describing the error,"
+    echo "along with the contents of ~/.local/bin/xivlauncher-custom.sh"
+    echo "===================== /usr/bin/xivlauncher custom ====================="
+    "$bindir/$script"
+}
+
+# Body of script
+if [ -z "$1" ];
+then
+    runDefault
 else
-    # xivlauncher-custom.sh wasn't found, so create it.
-    makeCustomScript
+    case $1 in
+        "CUSTOM" | "custom" | "Custom" )
+            checkCustom
+            runCustom
+        ;;
+        * )
+            echo "Error: Option '$1' is not valid."
+            runDefault
+        ;;
+    esac
 fi
-echo "Running script $xlpath."
-echo "If it crashes, please delete it, and run /usr/bin/xivlauncher again."
-echo "If the problem persists, please file a ticket on"
-echo "https://github.com/rankynbass/XIVLauncher4rpm describing the error,"
-echo "along with the contents of ~/.local/bin/xivlauncher-custom.sh"
-echo "=========================/usr/bin/xivlauncher========================="
-$xlpath


### PR DESCRIPTION
Redid the xivlauncher script

Running `/usr/bin/xivlauncher` with no arguements just launches XIVLauncher.

Running `/usr/bin/xivlauncher custom` will check for `$HOME/.local/bin/xivlauncher-custom.sh`, and launch it if it's found and has valid bash syntax.
- If the script is found, but is broken, it'll back it up and create a new one.
- If it doesn't find the custom script, it will created it.
- If the path `$HOME/.local/bin` doesn't exist, it will be created first. This fixes an error that was reported. This path is *not* part of the XDG basedir specs, but it *is* part of the systemd file heirarchy, and Fedora, openSUSE, Enterprise Linux, and most distros with systemd use it. 