### PR TITLE
Fix `freetype` dependency for openSUSE

### DIFF
--- a/XIVLauncher4rpm.spec
+++ b/XIVLauncher4rpm.spec
@@ -57,7 +57,7 @@ Requires:       (libXrandr or libXrandr2)
 Requires:       (libXdamage or libXdamage1)
 Requires:       (libXi or libXi6)
 Requires:       (gettext or gettext-runtime)
-Requires:       freetype
+Requires:       (freetype or libfreetype6)
 Requires:       (mesa-libGLU or libGLU1)
 Requires:       (libSM or libSM6)
 Requires:       (libgcc or libgcc_s1)


### PR DESCRIPTION
On openSUSE, the `freetype` package is named `libfreetype6`.

Relevant thread in the XIVLauncher Discord https://discord.com/channels/581875019861328007/850387047927250944/1221076857550671962.