### PR TITLE
Various cleanups

### DIFF
--- a/.copr/getsource.sh
+++ b/.copr/getsource.sh
@@ -24,7 +24,7 @@ curl -L https://github.com/goatcorp/XIVLauncher.Core/releases/download/${CoreTag
 
 cd "${repodir}" || exit
 mkdir -p "${workingdir}/XIVLauncher4rpm-${CoreTag}-${Release}"
-cp CHANGELOG.md README.md xivlauncher.png xivlauncher.sh xivlogo.png XIVLauncher.desktop COPYING "${workingdir}/XIVLauncher4rpm-${CoreTag}-${Release}/"
+cp CHANGELOG.md README.md xivlauncher.png xivlogo.png XIVLauncher.desktop COPYING "${workingdir}/XIVLauncher4rpm-${CoreTag}-${Release}/"
 cd "${workingdir}" || exit
 echo "Creating XIVLauncher4rpm-${CoreTag}-${Release}.tar.gz"
 tar -czf "${source1}" "XIVLauncher4rpm-${CoreTag}-${Release}"

--- a/XIVLauncher.desktop
+++ b/XIVLauncher.desktop
@@ -2,7 +2,7 @@
 Name=XIVLauncher RPM
 Comment=Custom launcher for Final Fantasy XIV. RPM (non-flatpak) version.
 Exec=/usr/bin/xivlauncher-core
-Icon=xivlauncher
+Icon=dev.goats.xivlauncher
 Terminal=false
 Type=Application
 Categories=Game;

--- a/XIVLauncher4rpm.spec
+++ b/XIVLauncher4rpm.spec
@@ -31,8 +31,7 @@ Release:        %{xlrelease}%{?dist}
 # Original Versioning: a.b.c.d-r
 # Epoch 1  Versioning: a.b.c-r
 Epoch:          1
-Summary:        Custom Launcher for the MMORPG Final Fantasy XIV (Native RPM package)
-Group:          Applications/Games
+Summary:        Custom Launcher for the MMORPG Final Fantasy XIV
 License:        GPL-3.0-only
 URL:            https://github.com/rankynbass/XIVLauncher4rpm
 Source0:        XIVLauncher.Core-%{xlversion}.tar.gz
@@ -72,11 +71,8 @@ Provides:       %{xlname}
 # Turn off build_id links to prevent conflict with main XIVLauncher package.
 %define _build_id_links none
 
-# Binaries will be deposited into this directory. Macro'd for convenience.
-%define launcher %{_builddir}/XIVLauncher
-
 %description
-Third-party launcher for the critically acclaimed MMORPG Final Fantasy XIV. This is a native build for fedora 36 and several other rpm based distos.
+Third-party launcher for the critically acclaimed MMORPG Final Fantasy XIV.
 
 ### PREP SECTION
 # Be aware that rpmbuild DOES NOT download sources from urls. It expects the source files to be in the %%{_sourcedir} directory.
@@ -97,17 +93,14 @@ Third-party launcher for the critically acclaimed MMORPG Final Fantasy XIV. This
 
 ### INSTALL SECTION
 %install
-install -d "%{buildroot}/usr/bin"
+install -d "%{buildroot}%{_bindir}"
 install -d "%{buildroot}/opt/xivlauncher"
-install -d "%{buildroot}/usr/share/doc/xivlauncher"
-install -d "%{buildroot}/usr/share/applications"
-install -D -m 644 "%{_builddir}/%{repo1}/xivlauncher.png" "%{buildroot}/usr/share/pixmaps/xivlauncher.png"
+install -d "%{buildroot}%{_datadir}/applications"
+install -D -m 644 "%{_builddir}/%{repo1}/xivlauncher.png" "%{buildroot}%{_datadir}/pixmaps/dev.goats.xivlauncher.png"
 cp -r "%{_builddir}/%{repo0}"/* "%{buildroot}/opt/xivlauncher"
 cp -r "%{_builddir}/%{repo1}"/* "%{buildroot}/opt/xivlauncher"
-cp %{buildroot}/opt/xivlauncher/COPYING %{buildroot}/usr/share/doc/xivlauncher/COPYING
-cd %{buildroot}
-ln -sr "opt/xivlauncher/xivlauncher.sh" "usr/bin/xivlauncher-core"
-ln -sr "opt/xivlauncher/XIVLauncher.desktop" "usr/share/applications/XIVLauncher.desktop"
+ln -sr "%{buildroot}/opt/xivlauncher/XIVLauncher.Core" "%{buildroot}/%{_bindir}/xivlauncher-core"
+mv "%{buildroot}/opt/xivlauncher/XIVLauncher.desktop" "%{buildroot}/%{_datadir}/applications/XIVLauncher.desktop"
 
 %pre
 
@@ -129,30 +122,25 @@ fi
 
 ### FILES SECTION
 %files
-/usr/bin/xivlauncher-core
-/usr/share/applications/XIVLauncher.desktop
-/usr/share/pixmaps/xivlauncher.png
-/opt/xivlauncher/CHANGELOG.md
-/opt/xivlauncher/COPYING
-/opt/xivlauncher/libcimgui.so
-/opt/xivlauncher/libskeychain.so
-/opt/xivlauncher/libsteam_api64.so
-/opt/xivlauncher/README.md
-/opt/xivlauncher/xivlauncher.sh
-/opt/xivlauncher/xivlauncher.png
-/opt/xivlauncher/XIVLauncher.Common.pdb
-/opt/xivlauncher/XIVLauncher.Common.Unix.pdb
-/opt/xivlauncher/XIVLauncher.Common.Unix.xml
-/opt/xivlauncher/XIVLauncher.Common.Windows.pdb
-/opt/xivlauncher/XIVLauncher.Common.Windows.xml
-/opt/xivlauncher/XIVLauncher.Common.xml
-/opt/xivlauncher/XIVLauncher.Core
-/opt/xivlauncher/XIVLauncher.Core.pdb
-/opt/xivlauncher/XIVLauncher.Core.xml
-/opt/xivlauncher/XIVLauncher.desktop
-/opt/xivlauncher/xivlogo.png
-%license /usr/share/doc/xivlauncher/COPYING
+%license /opt/xivlauncher/COPYING
+%doc /opt/xivlauncher/CHANGELOG.md
+%doc /opt/xivlauncher/README.md
+%{_bindir}/xivlauncher-core
+%{_datadir}/applications/XIVLauncher.desktop
+%{_datadir}/pixmaps/dev.goats.xivlauncher.png
+/opt/xivlauncher/
 
 %changelog
+* Thu Feb 26 2026 Tarulia <mihawk.90+git@googlemail.com>
+- removed unused, discouraged, and deprecated Group tag
+- removed unused macro definition
+- removed reference to F36 from Description
+- use RPM macros instead of absolute paths in install section
+- removed wrapper shellscript and symlinked binary directly
+- move .desktop file instead of symlinking it
+- rename application icon to match official Flatpak
+- proper doc and license tags for RPM payload data
+- package directory instead of individual file list
+
 * Mon Mar 31 2025 Rankyn Bass <rankyn@proton.me>
 - See CHANGELOG.md

--- a/_version
+++ b/_version
@@ -1,4 +1,4 @@
 XIVLauncher
 https://github.com/goatcorp/XIVLauncher.Core
 1.3.1
-1
+2


### PR DESCRIPTION
Decided to do some housekeeping. There are still quite a few things that could be done (especially when running through `rpmlint`), but these are fairly minor changes:

- removed unused, discouraged, and deprecated Group tag
	- this tag has been deprecated and discouraged in EL/Fedora for a decade now:
		- [https://fedoraproject.org/wiki/RPMGroups](https://fedoraproject.org/wiki/RPMGroups)
		- [https://pagure.io/packaging-committee/issue/679](https://pagure.io/packaging-committee/issue/679)
	- it's also unused in SUSE and the current string wouldn't follow SUSE packaging guidelines anyway
		- https://en.opensuse.org/openSUSE:Package_group_guidelines
		- https://en.opensuse.org/openSUSE:Specfile_guidelines
- removed unused macro definition
  - seems this is a leftover from when XL was still built during the RPM build
- removed reference to F36 from Description
  - the fact it's native is self-evident by just being an RPM
- use RPM macros instead of absolute paths in install section
- removed wrapper shellscript and symlinked binary directly
  - seems this was just a leftover from the old openSSL workaround removed in ec47f3b53c15b9778f648de5e322daa884b015cc
- move .desktop file instead of symlinking it
  - no reason to have this in /opt
- rename application icon to match official Flatpak
  - not strictly necessary, but if there's an official name we might as well use it
- proper doc and license tags for RPM payload data
  - copying these manually is not necessary, the macros are used to mark them as license and docs in the RPM payload data, and this works with any path:
    ```sh
    $ rpm -qd ./XIVLauncher-1.3.1-2.fc42.x86_64.rpm
    /opt/xivlauncher/CHANGELOG.md
    /opt/xivlauncher/README.md
    $ rpm -qL ./XIVLauncher-1.3.1-2.fc42.x86_64.rpm
    /opt/xivlauncher/COPYING
    ```
- package directory instead of individual file list
  - this makes sure the package owns the directory and not just the files in it
  - keeping a list of files separately is unnecessary maintenance

---

Tested by building on F42, EL9 and SUSE-TW chroots. Installed on F42 to make sure it works.